### PR TITLE
Source annotation: add Github links to new issue and file edit

### DIFF
--- a/jassbot/__init__.py
+++ b/jassbot/__init__.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 import socket
 import json
 import requests
+from urllib.parse import urlencode
 
 from jassbot.trie import Trie
 
@@ -268,7 +269,17 @@ def mk_bp(*args, **kwargs):
             elif annotation['name'] == 'pure':
                 annotations.append({"name": "pure", "html": "This function is pure. For the same values passed to it, it will always return the same value."})
             elif annotation['name'] == 'source-file':
-                annotations.append({"name": "Source", "html": '<a href="https://github.com/lep/jassdoc/blob/%s/%s#L%s">%s</a>' % (commit, annotation['value'], linenumber, annotation['value']) })
+                fileName = annotation['value']
+                permalink = 'https://github.com/lep/jassdoc/blob/%s/%s#L%s' % (commit, fileName, linenumber)
+                sourceFileLinkHtml = '<a href="%s">%s</a>' % (permalink, fileName)
+                # New issue link accepts either body or permalink, not both. Maybe aliases of one another.
+                newIssueLinkEncoded = 'https://github.com/lep/jassdoc/issues/new?' + 
+                    urlencode({"title": "[web] %s: %s - " % (fileName, entity),
+                              "body": permalink + "\n\nPlease change to a good descriptive title and tell us what should be improved.",
+                              })
+                editLink = 'https://github.com/lep/jassdoc/edit/master/%s#L%s' % (fileName, linenumber)
+                discussHtml = '(<a href="%s">suggest an edit</a> or <a href="%s">discuss on Github</a>)' % (editLink, newIssueLinkEncoded)
+                annotations.append({"name": "Source", "html": sourceFileLinkHtml + " " + discussHtml})
             elif annotation['name'] == 'source-code':
                 annotations.append({"name": "Source code", "html": "<pre><code>%s</code></pre>" % annotation['value']})
             elif annotation['name'] == 'return-type':


### PR DESCRIPTION
<img width="536" height="222" alt="source-example" src="https://github.com/user-attachments/assets/2bf5bd29-5960-47a1-836d-e5fd18b267e3" />

This is a suggestion. I've seen jassdoc being linked on Hive Discord quite often lately. Our friendliest offenders are insanity_ai and GrapesOfWath

There need to be links back to this repo to show people a straight forward way to contribute. Ain't nobody got time to find it out themselves. Based on experience, the form and wording and overall efficiency will depend on details and remains to be seen.

The edit link *must* point to a branch, therefore hardcoded as master.

Example edit link: https://github.com/lep/jassdoc/edit/master/flake.lock#L27-L30

Example issue link: https://github.com/lep/jassdoc/issues/new?title=%5Bweb%5D+flake.lock%3A+BlzFunction+-+&body=https%3A%2F%2Fgithub.com%2Flep%2Fjassdoc%2Fblob%2F654ce486e6fe1ea565de7c96104ac19d366cb311%2Fflake.lock%23L27%0A%0APlease+change+to+a+good+descriptive+title+and+tell+us+what+should+be+improved.

----

Should resulting in this html:

```
<a href="https://github.com/lep/jassdoc/blob/654ce486e6fe1ea565de7c96104ac19d366cb311/flake.lock#L27">flake.lock</a> (<a href="https://github.com/lep/jassdoc/edit/master/flake.lock#L27">suggest an edit</a> or <a href="https://github.com/lep/jassdoc/issues/new?title=%5Bweb%5D+flake.lock%3A+BlzFunction+-+&body=https%3A%2F%2Fgithub.com%2Flep%2Fjassdoc%2Fblob%2F654ce486e6fe1ea565de7c96104ac19d366cb311%2Fflake.lock%23L27%0A%0APlease+change+to+a+good+descriptive+title+and+tell+us+what+should+be+improved.">discuss on Github</a>)
```

---

1. May add a couple `\n` line breaks for HTML's readability rather than spaces.
2. Maybe instead of "suggest an edit" choose something else that doesn't sound like opening up a discussion? Although in all honesty, I think only people who have worked on Github before will figure out how to navigate the Edit & PR submission flow.
3. If we also add an end-line parameter to issue body's code link, then Github will preview the entire code. However it will not include our annotation comments, because start/end line only points to jass code? If anything, this is just readability help *when* you browse the issue on Github.
4. I noticed the camelcase convention at the end, but now idk what to do with my java-ish variable names in the lands of python 😅 

PS: Excuse me, but other than the string builder code, I haven't tested this.