### PR TITLE
Improve contrast for hl-dark.css

### DIFF
--- a/jassbot/static/jassbot/hl-dark.css
+++ b/jassbot/static/jassbot/hl-dark.css
@@ -3,12 +3,20 @@
 }
 
 .keyword {
-  color: gray;
+  color: rgb(170, 170, 170);
   font-weight: bold;
 }
 
 .ident {
-  color: white;
+  color: rgb(230,230,230);
+}
+
+.native a {
+  color: rgb(180,32,180);
+}
+
+.number {
+  color: rgb(51, 51, 240);
 }
 
 .string {
@@ -21,6 +29,10 @@
 
 .bool {
   color: lightblue;
+}
+
+.type a {
+  color: rgb(40, 90, 160);
 }
 
 .null {

--- a/jassbot/static/jassbot/hl-dark.css
+++ b/jassbot/static/jassbot/hl-dark.css
@@ -31,11 +31,6 @@
   color: lightblue;
 }
 
-.type a {
-  color: rgb(40, 90, 160);
-}
-
 .null {
   color: lightblue;
 }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jassbot-bp"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
     "flask",
     "markdown",


### PR DESCRIPTION
Old colors were too bright (numbers, literal) or too dim (native functions) to easily read against the dark gray background.

This is more of a hotfix, because without Dark Reader the dark theme is just awful to use. I eye-balled the values to my liking for now. I would want to revisit the light/dark styles later. No comparison screenshots, sorry :)